### PR TITLE
Add version constraints capability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,8 @@ QuickStart
 
    >> pipwin install opencv-python
 
+   >> pipwin install numpy>=1.11
+
 
 Details
 ^^^^^^^
@@ -55,12 +57,13 @@ Details
 - Search packages : ``pipwin search <partial_name/name>``
 
 - Install packages : ``pipwin install <package>``
+  Also works version specifiers, e.g. ``pipwin install <package>==<version>`` or ``pipwin install <package><=<version>``
 
 - Download only (to ~/pipwin) : ``pipwin download <package>``
 
-- Install from pipwin requirements file : ``pipwin install -file requirements.txt``
+- Install from pipwin requirements file : ``pipwin install -r requirements.txt``
 
-- Download only from pipwin requirements file : ``pipwin download -file requirements.txt``
+- Download only from pipwin requirements file : ``pipwin download -r requirements.txt``
 
 - Uninstall packages (Can directly use **pip** for this) : ``pipwin uninstall <package>``
 

--- a/pipwin/command.py
+++ b/pipwin/command.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 import platform
 from . import pipwin
+from packaging.requirements import Requirement
 
 
 def _package_names(args):
@@ -11,12 +12,12 @@ def _package_names(args):
         with open(args.file, 'r') as fid:
             for package in fid.readlines():
                 if package and not package.startswith('#'):
-                    yield package.strip()
+                    yield Requirement(package.strip())
     elif not args.package:
         print("Provide a package name")
         sys.exit(0)
     else:
-        yield args.package
+        yield Requirement(args.package)
     return
 
 
@@ -26,9 +27,8 @@ def _print_unresolved_match_msg(package, matches):
         print(" * " + "\n * ".join(matches))
         print("")
     else:
-        print("Package `{}` not found".format(package))
+        print("Package `{}` not found".format(package.name))
         print("Try `pipwin refresh`")
-
 
 def main():
     """
@@ -47,8 +47,7 @@ def main():
                                  "refresh"],
                         help="the action to perform")
     parser.add_argument("package", nargs="?", help="the package name")
-    parser.add_argument("-f", "--file", nargs="?",
-                        help="file with list of package names")
+    parser.add_argument("-r", "--file", nargs="?", help="file with list of package names")
 
     args = parser.parse_args()
 

--- a/pipwin/pipwin.py
+++ b/pipwin/pipwin.py
@@ -3,7 +3,6 @@
 import pip
 import requests
 from robobrowser import RoboBrowser
-from bs4 import BeautifulSoup
 from os.path import expanduser, join, isfile, exists
 import os
 import json
@@ -172,7 +171,6 @@ class PipwinCache(object):
         self.cache_file = join(home_dir, ".pipwin")
 
         if isfile(self.cache_file) and not refresh:
-            print(self.cache_file)
             with open(self.cache_file) as fp:
                 cache_dump = fp.read()
             self.data = json.loads(cache_dump)
@@ -202,7 +200,7 @@ class PipwinCache(object):
             print(package)
         print("")
 
-    def search(self, package):
+    def search(self, requirement):
         """
         Search for a package
 
@@ -214,39 +212,18 @@ class PipwinCache(object):
             List of matches. Is a string if exact_match is True.
         """
 
-        exact_match = package in self.sys_data.keys()
+        if requirement.name in self.sys_data.keys():
+            return [True, requirement.name]
 
-        if exact_match:
-            return [exact_match, package]
+        # find all packages that contain our search term within them
+        found = [pack for pack in self.sys_data.keys() if requirement.name in pack]
+        return [False, found]
 
-        found = []
-        for pack in self.sys_data.keys():
-            if package in pack:
-                # Partial string search
-                found.append(pack)
-
-        return [exact_match, found]
-
-    def _get_url(self, package):
-        url = None
-        if len(self.sys_data[package]) == 1:
-            url = six.next(six.itervalues(self.sys_data[package]))
-        else:
-            print("Choose version to download.\n")
-            ver_keys = list(self.sys_data[package].keys())
-            for index, version in enumerate(ver_keys):
-                print("[" + str(index) + "] : " + str(version))
-
-            while True:
-                try:
-                    selected_id = int(input("\nType version id shown in box : "))
-                    url = self.sys_data[package][ver_keys[selected_id]]
-                    break
-                except ValueError:
-                    print("Id should be a valid integer")
-                except IndexError:
-                    print("Id should be in the available range")
-        return url
+    def _get_url(self, requirement):
+        versions = list(requirement.specifier.filter(self.sys_data[requirement.name].keys()))
+        if not versions:
+            raise ValueError("Could not satisfy requirement %s"%(str(requirement)))
+        return self.sys_data[requirement.name][max(versions)]
 
     def _get_pipwin_dir(self):
         home_dir = expanduser("~")
@@ -261,8 +238,8 @@ class PipwinCache(object):
             return None
         return bar
 
-    def _download(self, package):
-        url = self._get_url(package)
+    def _download(self, requirement):
+        url = self._get_url(requirement)
         wheel_name = url.split("/")[-1]
         print("Downloading package . . .")
         print(url)
@@ -284,24 +261,24 @@ class PipwinCache(object):
                     bar.update()
         return wheel_file
 
-    def download(self, package):
-        self._download(package)
+    def download(self, requirement):
+        return self._download(requirement)
 
-    def install(self, package):
+    def install(self, requirement):
         """
         Install a package
         """
-        wheel_file = self._download(package)
+        wheel_file = self.download(requirement)
         pip.main(["install", wheel_file])
 
         os.remove(wheel_file)
 
-    def uninstall(self, package):
+    def uninstall(self, requirement):
         """
         Uninstall a package
         """
 
-        pip.main(["uninstall", self.sys_data[package]])
+        pip.main(["uninstall", self.sys_data[requirement.name]])
 
 
 def refresh():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ robobrowser
 requests
 pyprind
 six
+packaging

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,13 @@ requirements = [
     "requests",
     "robobrowser",
     "pyprind",
-    "six"
+    "six",
+    "packaging",
 ]
 
 setup(
     name="pipwin",
-    version="0.2.5",
+    version="0.3",
     description="pipwin installs compiled python binaries on windows provided by Christoph Gohlke",
     long_description=readme,
     author="lepisma",


### PR DESCRIPTION
* We no longer prompt the user for which version to install, we just
always install the latest.  If the user wants an older version, they
need to ask on the commandline, just like `pip`.

* We use `packaging` to do the requirement parsing for us.

* We change the requirements.txt input short switch to `-r` from `-f` to
more closely track `pip`.

* Bump version number to `0.3` because this is backwards-incompatible
behavior