### PR TITLE
Tweaks to prevent 404

### DIFF
--- a/pipwin/pipwin.py
+++ b/pipwin/pipwin.py
@@ -27,7 +27,7 @@ except NameError:
 MAIN_URL = "http://www.lfd.uci.edu/~gohlke/pythonlibs/"
 
 HEADER = {
-    "Host": "www.lfd.uci.edu",
+    'Host' : 'download.lfd.uci.edu',
     "Connection": "keep-alive",
     "Cache-Control": "max-age=0",
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
@@ -36,7 +36,6 @@ HEADER = {
     "DNT": "1",
     "Accept-Encoding": "gzip, deflate, sdch",
     "Accept-Language": "en-US,en;q=0.8",
-    "Referer": "http://www.lfd.uci.edu/~gohlke/pythonlibs/"
 }
 
 class DESAdapter(HTTPAdapter):
@@ -59,7 +58,7 @@ class DESAdapter(HTTPAdapter):
         kwargs['ssl_context'] = context
         self.poolmanager = PoolManager(
             num_pools=connections, maxsize=maxsize,
-            block=block, ssl_version=ssl.PROTOCOL_TLS, *args, **kwargs)
+            block=block, ssl_version=ssl.PROTOCOL_SSLv23, *args, **kwargs)
 
 
 def build_cache():
@@ -260,9 +259,7 @@ class PipwinCache(object):
 
         wheel_file = join(self._get_pipwin_dir(), wheel_name)
 
-        sess = requests.Session()
-        sess.mount('https://', DESAdapter())
-        res = sess.get(url, headers=HEADER, stream=True)
+        res = requests.get(url, headers=HEADER, stream=True)
 
         length = res.headers.get("content-length")
         chunk = 1024

--- a/pipwin/pipwin.py
+++ b/pipwin/pipwin.py
@@ -27,7 +27,7 @@ except NameError:
 MAIN_URL = "http://www.lfd.uci.edu/~gohlke/pythonlibs/"
 
 HEADER = {
-    'Host' : 'download.lfd.uci.edu',
+    "Host" : "download.lfd.uci.edu",
     "Connection": "keep-alive",
     "Cache-Control": "max-age=0",
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",


### PR DESCRIPTION
I just tried using v0.3.3 and for some reason it didn't work in a clean env - I got the same errors about "invalid zip file" which were caused by the whl file not downloading. The tweaks to the request headers in this PR seemed to resolve the error by stopping the server responding with 404 - hopefully the CI tests start passing now!

edit: nope, that made it worse. probably because I messed up the headers when it builds the cache. Will have another look later