### PR TITLE
Release 0.4.8 Fix for issue: corrupt wheels — 404 errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,14 @@ Details
 Changelog
 ---------
 
+v0.4.8
+~~~~~~
+
+-  Using pySmartDL to handle download and install of packages.
+-  Removed progress bar and streaming downloader
+
 v0.4.7
 ~~~~~~
 
 -  Using postman client type to overcome use of robobrowser to create package cache.
+

--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,8 @@ Changelog
 v0.4.8
 ~~~~~~
 
--  Using pySmartDL to handle download and install of packages.
--  Removed progress bar and streaming downloader
+-  Using PySmartDL to handle download and install of packages.
+-  Removed progress bar and streaming downloader blocks now handled by PySmartDL.
 
 v0.4.7
 ~~~~~~

--- a/pipwin/__init__.py
+++ b/pipwin/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.4.7"
+__version__ = "0.4.8"

--- a/pipwin/pipwin.py
+++ b/pipwin/pipwin.py
@@ -14,6 +14,7 @@ import js2py
 from bs4 import BeautifulSoup
 import re
 import ssl
+from pySmartDL import SmartDL
 from requests.adapters import HTTPAdapter
 from urllib3.poolmanager import PoolManager
 from urllib3.util.ssl_ import create_urllib3_context
@@ -265,12 +266,6 @@ class PipwinCache(object):
             os.makedirs(pipwin_dir)
         return pipwin_dir
 
-    def _get_progress_bar(self, length, chunk):
-        bar = pyprind.ProgBar(int(length) / chunk)
-        if int(length) < chunk:
-            return None
-        return bar
-
     def _download(self, requirement, dest):
         url = self._get_url(requirement)
         wheel_name = url.split("/")[-1]
@@ -291,19 +286,8 @@ class PipwinCache(object):
             print("File " + wheel_file + " already exists")
             return wheel_file
 
-        res = requests.get(url, headers=HEADER, stream=True)
-
-        length = res.headers.get("content-length")
-        chunk = 1024
-
-        bar = self._get_progress_bar(length, chunk)
-
-        with open(wheel_file, "wb") as wheel_handle:
-            for block in res.iter_content(chunk_size=chunk):
-                wheel_handle.write(block)
-                wheel_handle.flush()
-                if bar is not None:
-                    bar.update()
+        obj = SmartDL(url, dest)
+        obj.start()
         return wheel_file
 
     def download(self, requirement, dest=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyprind
 six
 js2py
 packaging
+pySmartDL

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ pyprind
 six
 js2py
 packaging
-pySmartDL

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,12 @@ requirements = [
     "beautifulsoup4",
     "js2py",
     "packaging",
+    "pySmartDL",
 ]
 
 setup(
     name="pipwin",
-    version="0.4.7",
+    version="0.4.8",
     description="pipwin installs compiled python binaries on windows provided by Christoph Gohlke",
     long_description=readme,
     author="lepisma",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
     "beautifulsoup4",
     "js2py",
     "packaging",
-    "pySmartDL==1.2.5;python_version<'3.4'",
+    "pySmartDL==1.2.4;python_version<'3.4'",
     "pySmartDL>=1.3.1;python_version>='3.4'",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ requirements = [
     "beautifulsoup4",
     "js2py",
     "packaging",
-    "pySmartDL",
+    "pySmartDL==1.2.5;python_version<'3.4'",
+    "pySmartDL>=1.3.1;python_version>='3.4'",
 ]
 
 setup(


### PR DESCRIPTION
Suggested [Fix for Issue 40](https://github.com/lepisma/pipwin/issues/40)

Adding an additional dependency but this streamlines downloader without need for some agents working for caching and some failing for downloading. The pysmartDL lib also maintains the progress bar and is a quick downloader and can handle the installation.