### PR TITLE
Fixes for requirements parsing

### DIFF
--- a/pipwin/command.py
+++ b/pipwin/command.py
@@ -30,10 +30,11 @@ from packaging.requirements import Requirement
 
 def _package_names(args):
     if args["--file"]:
-        with open(args["--file"], 'r') as fid:
+        with open(args["--file"], 'rt') as fid:
             for package in fid.readlines():
+                package = package.strip()
                 if package and not package.startswith('#'):
-                    yield Requirement(package.strip())
+                    yield Requirement(package)
     elif not args["<package>"]:
         print("Provide a package name")
         sys.exit(0)


### PR DESCRIPTION
1. use text mode for opening requirements files so newlines are handled correctly cross-platform
2. strip trailing whitespace before checking for empty lines to skip

pipwin was failing before with a CRLF-delimited requirements file that looked like this, because `package=='\n'` on the empty line, so it was being treated as a package and parsed via `Requirement('')`. (Python 3.7/Windows)

```
# some comment

apackage==1.2.3
```

With the traceback:
```
> pipwin download -r windows-requirements.txt
Traceback (most recent call last):
  File "d:\users\me\app\venv\lib\site-packages\packaging\requirements.py", line 98, in __init__
    req = REQUIREMENT.parseString(requirement_string)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 1947, in parseString
    raise exc
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 1937, in parseString
    loc, tokens = self._parse(instring, 0)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 1677, in _parseNoCache
    loc, tokens = self.parseImpl(instring, preloc, doActions)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 4052, in parseImpl
    loc, exprtokens = e._parse(instring, loc, doActions)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 1677, in _parseNoCache
    loc, tokens = self.parseImpl(instring, preloc, doActions)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 4445, in parseImpl
    return self.expr._parse(instring, loc, doActions, callPreParse=False)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 1677, in _parseNoCache
    loc, tokens = self.parseImpl(instring, preloc, doActions)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 4035, in parseImpl
    loc, resultlist = self.exprs[0]._parse(instring, loc, doActions, callPreParse=False)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 1677, in _parseNoCache
    loc, tokens = self.parseImpl(instring, preloc, doActions)
  File "d:\users\me\app\venv\lib\site-packages\pyparsing.py", line 3234, in parseImpl
    raise ParseException(instring, loc, self.errmsg, self)
pyparsing.ParseException: Expected W:(abcd...)  (at char 0), (line:1, col:1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\Users\me\app\venv\Scripts\pipwin-script.py", line 11, in <module>
    load_entry_point('pipwin==0.4.8', 'console_scripts', 'pipwin')()
  File "d:\users\me\app\venv\lib\site-packages\pipwin\command.py", line 85, in main
    for package in _package_names(args):
  File "d:\users\me\app\venv\lib\site-packages\pipwin\command.py", line 36, in _package_names
    yield Requirement(package.strip())
  File "d:\users\me\app\venv\lib\site-packages\packaging\requirements.py", line 102, in __init__
    requirement_string[e.loc : e.loc + 8], e.msg
packaging.requirements.InvalidRequirement: Parse error at "''": Expected W:(abcd...)
```