### PR TITLE
Added proxy support

### DIFF
--- a/pipwin/command.py
+++ b/pipwin/command.py
@@ -64,6 +64,10 @@ def main():
     # Warn if not on windows
     if platform.system() != "Windows":
         warn("Found a non Windows system. Package installation might not work.")
+    
+    # Sets the proxy
+    if args['--proxy']:
+        pipwin.set_proxy(args['--proxy'])
 
     # Handle refresh
     if args["refresh"]:

--- a/pipwin/command.py
+++ b/pipwin/command.py
@@ -3,12 +3,12 @@
 Gohlke
 
 Usage:
-  pipwin install (<package> | [-r=<file> | --file=<file>])
+  pipwin install (<package> | [-r=<file> | --file=<file>]) [--proxy=<proxy>]
   pipwin uninstall <package>
-  pipwin download (<package> | [-r=<file> | --file=<file>]) [-d=<dest> | --dest=<dest>]
-  pipwin search <package>
+  pipwin download (<package> | [-r=<file> | --file=<file>]) [-d=<dest> | --dest=<dest>] [--proxy=<proxy>]
+  pipwin search <package> [--proxy=<proxy>]
   pipwin list
-  pipwin refresh [--log=<log>]
+  pipwin refresh [--log=<log>] [--proxy=<proxy>]
   pipwin (-h | --help)
   pipwin (-v | --version)
 
@@ -17,6 +17,7 @@ Options:
   -v --version             Show version.
   -r=<file> --file=<file>  File with list of package names.
   -d=<dest> --dest=<dest>  Download packages into <dest>.
+  --proxy=<proxy>          Uses the specified proxy
 """
 
 from docopt import docopt

--- a/pipwin/pipwin.py
+++ b/pipwin/pipwin.py
@@ -307,6 +307,17 @@ class PipwinCache(object):
         """
         subprocess.check_call([executable, "-m", "pip", "uninstall", requirement.name])
 
+def set_proxy(proxy):
+    """
+    Set a proxy to the environment
+    """
+    # PySmartDL ignores http_proxy, but it is used on build_cache()
+    # urllib.request ignores lowercase proxy env variable if user also have a REQUEST_METHOD env var
+    # To avoid similar issues, added all cases
+    os.environ['http_proxy'] = proxy 
+    os.environ['HTTP_PROXY'] = proxy
+    os.environ['https_proxy'] = proxy
+    os.environ['HTTPS_PROXY'] = proxy
 
 def refresh():
     """


### PR DESCRIPTION
Following issue #31, added support for a proxy argument, similar to pip's one (using --proxy on the CLI). The proxy is added to the environment variables, since PySmartDL does not support it, but uses urllib, which ultimately accepts the env vars.

Since build_cache does not use PySmartDL, but _download does, behaviour differs with the command entered, and so does the environment variable used by the request. Hence, the same proxy is set for different variable names. 