### PR TITLE
Fixed issue where install -r (filename) does not work

### DIFF
--- a/pipwin/command.py
+++ b/pipwin/command.py
@@ -35,7 +35,7 @@ def _package_names(args):
             for package in fid.readlines():
                 package = package.strip()
                 if package and not package.startswith('#'):
-                    yield Requirement(package)
+                    yield Requirement(package.lower())
     elif not args["<package>"]:
         print("Provide a package name")
         sys.exit(0)


### PR DESCRIPTION
It is required by the packages in requirements.txt to be all lower case currently to be working, this resolves the issue by doing .lower()
Issue 60: https://github.com/lepisma/pipwin/issues/60